### PR TITLE
Make the mssql library parameters more customizable. Set new connection pool timeouts by default, and change some defaults.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     },
     "homepage": "https://github.com/stevenvelozo/meadow-connection-mssql",
     "devDependencies": {
-        "quackage": "^1.0.19"
+        "quackage": "^1.0.19",
+        "sinon": "^17.0.1"
     },
     "dependencies": {
         "fable-serviceproviderbase": "^3.0.4",

--- a/test/MSSQL_tests.js
+++ b/test/MSSQL_tests.js
@@ -10,8 +10,12 @@ const Chai = require('chai');
 const Expect = Chai.expect;
 const Assert = Chai.assert;
 
+const Util = require('util');
 const libFable = require('fable');
 const libMeadowConnectionMSSQL = require('../source/Meadow-Connection-MSSQL.js');
+
+const libMSSQL = require('mssql');
+const libSinon = require('sinon');
 
 const _FableConfig = (
 	{
@@ -78,10 +82,88 @@ suite
 										Expect(pRows.recordset).to.be.an('array');
 										//Expect(pRows.length).to.equal(10);
 										//Expect(pRows[0].Title).to.equal(`Harry Potter and the Philosopher's Stone`);
-										return fDone();
+										if (!_Fable.MeadowMSSQLProvider.pool)
+										{
+											return fDone();
+										}
+										return _Fable.MeadowMSSQLProvider.pool.close().finally(fDone);
 									});
 							}
 						);
+					}
+				);
+			}
+		);
+		suite
+		(
+			'Marshall options to pool',
+			()=>
+			{
+				teardown(() => { libSinon.restore(); });
+
+				test
+				(
+					'allows simple property overrides',
+					async () =>
+					{
+						// given
+						libSinon.spy(libMSSQL, 'connect');
+						const tmpMSSQLOptions = { trustServerCertificate: false };
+						const _Fable = new libFable(_FableConfig);
+						_Fable.serviceManager.addServiceType('MeadowMSSQLProvider', libMeadowConnectionMSSQL);
+
+						const provider = _Fable.serviceManager.instantiateServiceProvider('MeadowMSSQLProvider', tmpMSSQLOptions);
+
+						Expect(_Fable.MeadowMSSQLProvider).to.be.an('object');
+
+						// when
+						let pool;
+						try
+						{
+							pool = await Util.promisify(provider.connectAsync).bind(provider)();
+						}
+						catch (err)
+						{
+							Expect(err.message).to.include('self signed certificate');
+						}
+
+						// then
+						Expect(libMSSQL.connect.callCount).to.equal(1);
+						Expect(libMSSQL.connect.getCall(0).args[0].options?.trustServerCertificate).to.be.false;
+						await pool?.close();
+					}
+				);
+
+				test
+				(
+					'allows simple property overrides',
+					async () =>
+					{
+						// given
+						libSinon.spy(libMSSQL, 'connect');
+						const tmpMSSQLOptions = { MSSQLConnectSettingOverrides: { options: { trustServerCertificate: false } } };
+						const _Fable = new libFable(_FableConfig);
+						_Fable.serviceManager.addServiceType('MeadowMSSQLProvider', libMeadowConnectionMSSQL);
+
+						const provider = _Fable.serviceManager.instantiateServiceProvider('MeadowMSSQLProvider', tmpMSSQLOptions);
+
+						Expect(_Fable.MeadowMSSQLProvider).to.be.an('object');
+
+						// when
+						let pool;
+						try
+						{
+							pool = await Util.promisify(provider.connectAsync).bind(provider)();
+						}
+						catch (err)
+						{
+							Expect(err.message).to.include('self signed certificate');
+						}
+
+						// then
+						Expect(libMSSQL.connect.callCount).to.equal(1);
+						Expect(libMSSQL.connect.getCall(0).args[0].options?.trustServerCertificate).to.be.false;
+						await pool?.close();
 					}
 				);
 			}


### PR DESCRIPTION
* Added simple overrides for most parameters already being set by the provider.
* Added open-ended merge-based override for any other parameters needed. It uses the `FableSettings` `merge` method for simplicity.
* Updated some logging that wasn't being very helpful.
* Added tests for both flavors.

Tests passing for me.

Risk: I am using the nullish coalescing operator (`??`) for brevity. This requires Node v14 or later. See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing